### PR TITLE
Split App Config

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/app/Config/App.php
+++ b/app/Config/App.php
@@ -6,21 +6,6 @@ use CodeIgniter\Config\BaseConfig;
 
 class App extends BaseConfig
 {
-	// Cache expiration time for GitHub data
-	public $gitHubExpires = 14400; // 4 hours
-
-	/*
-	|--------------------------------------------------------------------------
-	| MY BB Forum configurations
-	|--------------------------------------------------------------------------
-	| @mybb_news_forum_id - Code for the news forum in our MyBB
-	| @mybb_news_usernames - An array of user names to restrict our search for news articles to. This simply helps limit the work to do.
-	| @mybb_forum_url - The link to direct visitors to for our forum
-	 */
-	public $mybbNewsForum_id = 2;
-	public $mybbNewsUsernames = ['ciadmin', 'jlp', 'kilishan', 'Narf'];
-	public $mybbForumURL = 'https://forum.codeigniter.com';
-
 	/**
 	 * --------------------------------------------------------------------------
 	 * Base Site URL

--- a/app/Config/GitHub.php
+++ b/app/Config/GitHub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class GitHub extends BaseConfig
+{
+	/**
+	 * Cache expiration time for GitHub data
+	 *
+	 * @var int
+	 */
+	public $expires = HOUR * 4;
+}

--- a/app/Config/MyBB.php
+++ b/app/Config/MyBB.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+class MyBB extends BaseConfig
+{
+	/**
+	 * --------------------------------------------------------------------------
+	 * MyBB Forum ID
+	 * --------------------------------------------------------------------------
+	 *
+	 * Code for the news forum in our MyBB
+	 */
+	public $newsForumId = 2;
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * MyBB Usernames
+	 * --------------------------------------------------------------------------
+	 *
+	 * An array of user names to restrict our search for news articles to.
+	 * This simply helps limit the work to do.
+	 */
+	public $newsUsernames = ['ciadmin', 'jlp', 'kilishan', 'Narf'];
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * MyBB Forum URL
+	 * --------------------------------------------------------------------------
+	 *
+	 * The link to direct visitors to for our forum
+	 */
+	public $forumURL = 'https://forum.codeigniter.com';
+}

--- a/app/Libraries/Forums.php
+++ b/app/Libraries/Forums.php
@@ -25,7 +25,7 @@ class Forums
     public function __construct()
     {
         $this->mybb = new MyBBModel();
-        $this->forumUrl = config('App')->mybbForumURL;
+        $this->forumUrl = config('MyBB')->forumURL;
     }
 
     /**

--- a/app/Libraries/GitHubHelper.php
+++ b/app/Libraries/GitHubHelper.php
@@ -39,7 +39,7 @@ class GitHubHelper
      */
     public function fillReleaseInfo(array $data): array
     {
-        $ttl = config('App')->gitHubExpires;
+        $ttl = config('GitHub')->expires;
 
         if (! $info4 = cache('info4')) {
             $info4 = $this->api->getLatestRelease('codeigniter4', 'framework');
@@ -73,7 +73,7 @@ class GitHubHelper
      */
     public function fillRepoInfo(array $data): array
     {
-        $ttl = config('App')->gitHubExpires;
+        $ttl = config('GitHub')->expires;
 
         // get the repo stats
         if ( ! $info = cache('repo_info'))
@@ -101,7 +101,7 @@ class GitHubHelper
      */
     public function fillHeroes(array $data): array
     {
-        $ttl = config('App')->gitHubExpires;
+        $ttl = config('GitHub')->expires;
 
         // get the framework heroes
         if ( ! $info = cache('fw_heroes'))


### PR DESCRIPTION
Splits out additional content in `App` into their own config files.

Alternative implementation would be to create a single **app/Config/Project.php** to hold all of this. Regardless of implementation I believe in keeping `App` strictly to its original framework content.